### PR TITLE
Fix for issue #8 

### DIFF
--- a/conrad/cli.py
+++ b/conrad/cli.py
@@ -162,7 +162,7 @@ def _show(ctx, *args, **kwargs):
         session.close()
         click.echo(t)
     else:
-        click.echo("No events found!")
+        click.echo("No events found, refresh to pull events!")
 
 
 @cli.command("remind")

--- a/conrad/cli.py
+++ b/conrad/cli.py
@@ -84,6 +84,13 @@ def _refresh(ctx, *args, **kwargs):
 @click.pass_context
 def _show(ctx, *args, **kwargs):
     # TODO: conrad show --new
+    
+    if not os.path.exists(CONRAD_HOME):
+        os.makedirs(CONRAD_HOME)
+
+    if not os.path.exists(os.path.join(CONRAD_HOME, "conrad.db")):
+        initialize_database()
+
     cfp = kwargs["cfp"]
     tag = kwargs["tag"]
     name = kwargs["name"]


### PR DESCRIPTION
1. When user types `conrad show` as first command post installation , it will throw db error as db not present , hence we need to initialize db if user types in the the show as first command and give message as  to refresh to show the events further, 
