### PR TITLE
#19 Renamed tabled headers to uppercase and removed underscores

### DIFF
--- a/conrad/cli.py
+++ b/conrad/cli.py
@@ -141,14 +141,14 @@ def _show(ctx, *args, **kwargs):
 
     t = PrettyTable()
     t.field_names = [
-        "id",
-        "name",
-        "url",
-        "city",
-        "state",
-        "country",
-        "start_date",
-        "end_date",
+        "Id",
+        "Name",
+        "Url",
+        "City",
+        "State",
+        "Country",
+        "Start Date",
+        "End Date",
     ]
     t.align = "l"
 


### PR DESCRIPTION
Fixed issue #19 . Table headers are as follows:
        Id
        Name
        Url
        City
        State
        Country
        Start Date
        End Date