### PR TITLE
#10 Fixed issue of removing old conferences during import

### DIFF
--- a/conrad/cli.py
+++ b/conrad/cli.py
@@ -141,14 +141,14 @@ def _show(ctx, *args, **kwargs):
 
     t = PrettyTable()
     t.field_names = [
-        "id",
-        "name",
-        "url",
-        "city",
-        "state",
-        "country",
-        "start_date",
-        "end_date",
+        "Id",
+        "Name",
+        "Url",
+        "City",
+        "State",
+        "Country",
+        "Start Date",
+        "End Date",
     ]
     t.align = "l"
 


### PR DESCRIPTION
Fixed issue #10 

Added functionality in _import() function to check date in events and remove it if it has passed current date. Same for new events that are to be passed which have to undergo this check. 