### PR TITLE
[Issue-33] Use last_updated_at to refresh db <Anusha>

### DIFF
--- a/conrad/cli.py
+++ b/conrad/cli.py
@@ -15,6 +15,7 @@ from .db import engine, Session
 from .prettytable import PrettyTable
 from .models import Base, Event, Reminder
 from .utils import initialize_database, validate
+from datetime import datetime, timedelta
 
 
 def get_events():
@@ -97,7 +98,12 @@ def _show(ctx, *args, **kwargs):
         click.echo("Event database not found, fetching it!")
         get_events()
         initialize_database()
+    
+    session = Session()
 
+    last_updated_event = session.query(Event).order_by(Event.last_updated_at.desc()).first()
+
+    if datetime.utcnow() > (last_updated_event.last_updated_at + timedelta(hours=2)):
         with open(os.path.join(CONRAD_HOME, "events.json"), "r") as f:
             events = json.load(f)
         refresh_database(events)
@@ -152,7 +158,6 @@ def _show(ctx, *args, **kwargs):
     ]
     t.align = "l"
 
-    session = Session()
     events = list(
         session.query(Event).filter(*filters).order_by(Event.start_date).all()
     )

--- a/conrad/models.py
+++ b/conrad/models.py
@@ -1,10 +1,15 @@
 # -*- coding: utf-8 -*-
 
-from sqlalchemy import Boolean, Column, DateTime, Integer, String, Text, ForeignKey
+from sqlalchemy import Boolean, Column, DateTime, Integer, String, Text, ForeignKey, TIMESTAMP
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import func
 
+class Base(object):
+    def __tablename__(self):
+        return self.__name__
+    last_updated_at = Column(TIMESTAMP, server_default=func.now(), onupdate=func.current_timestamp())    
 
-Base = declarative_base()
+Base = declarative_base(cls=Base)
 ID_LEN = 100
 STR_LEN = 1024
 


### PR DESCRIPTION
**Issue:**
This PR is related to the issue: https://github.com/vinayak-mehta/conrad/issues/33

**Summary of changes:**
1. Use SqlAlchemy event to set last_updated_at in db
2. Retrieve the latest last_updated_at value
3. If current time is greater than last_updated_at + 2 hours, refresh_database()