### PR TITLE
[MRG] Add nominatim geocoder to standardize location

### DIFF
--- a/conrad/utils.py
+++ b/conrad/utils.py
@@ -5,10 +5,6 @@ from .db import engine
 import geopy.exc as geopyexceptions
 from geopy.geocoders import Nominatim
 from geopy.extra.rate_limiter import RateLimiter
-# open street maps nominatim geocoder
-geolocator = Nominatim(user_agent='conrad')
-# Delay between geocoding calls to not run out of calls
-geocode = RateLimiter(geolocator.geocode, min_delay_seconds=5)
 
 
 def initialize_database():
@@ -57,28 +53,21 @@ def validate(input_events):
     return failures
 
 
-"""Function is deliberately made recursive
-    to avoid timeout error
-"""
-def standard_address(place):
-    """Return the standard address
-    as dict given the name of a place
+def get_address(place):
+    geolocator = Nominatim(user_agent="conrad")
+    geocode = RateLimiter(geolocator.geocode, min_delay_seconds=5)
 
-    place (str): name of the place
-    returs (dict): standard address
-    """
+    address = None
     try:
         location = geolocator.geocode(place)
-        if location:
+        if location is not None:
             address = geolocator.reverse(
                 "{lat}, {lon}".format(lat=location.latitude, lon=location.longitude)
             ).raw["address"]
-            address['latitude'] = location.latitude
-            address['longitude'] = location.longitude
-        else:
-            # unable to geocode :(
-            address = {}
-        return address
+            address["latitude"] = location.latitude
+            address["longitude"] = location.longitude
     except geopyexceptions.GeocoderTimedOut:
-        # Timeout try again
-        standard_address(place)
+        # TODO: add 2 retries using tenacity
+        print(f"Geocoder timed out for {place}!")
+
+    return address

--- a/conrad/utils.py
+++ b/conrad/utils.py
@@ -2,6 +2,14 @@
 
 from .db import engine
 
+import geopy.exc as geopyexceptions
+from geopy.geocoders import Nominatim
+from geopy.extra.rate_limiter import RateLimiter
+# open street maps nominatim geocoder
+geolocator = Nominatim(user_agent='conrad')
+# Delay between geocoding calls to not run out of calls
+geocode = RateLimiter(geolocator.geocode, min_delay_seconds=5)
+
 
 def initialize_database():
     from .models import Base
@@ -47,3 +55,30 @@ def validate(input_events):
             break
 
     return failures
+
+
+"""Function is deliberately made recursive
+    to avoid timeout error
+"""
+def standard_address(place):
+    """Return the standard address
+    as dict given the name of a place
+
+    place (str): name of the place
+    returs (dict): standard address
+    """
+    try:
+        location = geolocator.geocode(place)
+        if location:
+            address = geolocator.reverse(
+                "{lat}, {lon}".format(lat=location.latitude, lon=location.longitude)
+            ).raw["address"]
+            address['latitude'] = location.latitude
+            address['longitude'] = location.longitude
+        else:
+            # unable to geocode :(
+            address = {}
+        return address
+    except geopyexceptions.GeocoderTimedOut:
+        # Timeout try again
+        standard_address(place)

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,12 @@ requires = [
     "requests==2.22.0",
     "SQLAlchemy==1.3.10",
     "textdistance==4.1.5",
+    "geopy==1.20.0"
 ]
-dev_requires = ["Sphinx==2.2.1"]
+dev_requires = [
+    "Sphinx==2.2.1",
+    "pytest>=3.8.0"
+]
 dev_requires = dev_requires + requires
 
 

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -1,13 +1,15 @@
-"""-*- coding: utf-8 -*-."""
+# -*- coding: utf-8 -*-
 
-from conrad.utils import standard_address
+from conrad.utils import get_address
+
 
 NYC_ADDRESS = {
-    "townhall": "New York City Hall",
+    "amenity": "New York City Hall",
     "house_number": "260",
     "road": "Broadway",
+    "neighbourhood": "Civic Center",
     "suburb": "Manhattan",
-    "city": "New York",
+    "city": "Manhattan Community Board 1",
     "county": "New York County",
     "state": "New York",
     "postcode": "10000",
@@ -18,10 +20,13 @@ NYC_ADDRESS = {
 }
 
 
-def test_standard_address():
-    """Test standard address geocoding."""
-    bad_place = "doesnotexist"
-    empty = standard_address(bad_place)
-    good_place = "New York"
-    nyc = standard_address(good_place)
-    assert (empty, nyc) == ({}, nyc)
+def test_bad_place():
+    place = "doesnotexist"
+    address = get_address(place)
+    assert address is None
+
+
+def test_good_place():
+    place = "New York"
+    address = get_address(place)
+    assert address == NYC_ADDRESS

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -1,0 +1,27 @@
+"""-*- coding: utf-8 -*-."""
+
+from conrad.utils import standard_address
+
+NYC_ADDRESS = {
+    "townhall": "New York City Hall",
+    "house_number": "260",
+    "road": "Broadway",
+    "suburb": "Manhattan",
+    "city": "New York",
+    "county": "New York County",
+    "state": "New York",
+    "postcode": "10000",
+    "country": "United States of America",
+    "country_code": "us",
+    "latitude": 40.7127281,
+    "longitude": -74.0060152,
+}
+
+
+def test_standard_address():
+    """Test standard address geocoding."""
+    bad_place = "doesnotexist"
+    empty = standard_address(bad_place)
+    good_place = "New York"
+    nyc = standard_address(good_place)
+    assert (empty, nyc) == ({}, nyc)


### PR DESCRIPTION
Closes #37 

Added a function to fetch a dict of standard address attributes for any given location and also an additional testcase 
```
[1] %timeit standard_address('london')
4.87 s ± 2.16 s per loop (mean ± std. dev. of 7 runs, 1 loop each)
```


This PR would mean changes to schema / a new JSON location field based on the scraped city, state, country and/or other location attributes 

We could also extend this  to get all conferences around the users given a distance buffer
https://github.com/vinayak-mehta/conrad/issues/37#issuecomment-547309023
```conrad show --nearby 100``` could get users latlong with https://ipinfo.io/ and then can fetch all conferences with a 100 kms/miles or any given distance buffer, 


We could also consider taking up ```conrad map``` #38 

