### PR TITLE
Adding to the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ requires = [
     "rich>=10.6.0",
     "SQLAlchemy>=1.3.10",
     "textdistance>=4.1.5",
+    "packaging>=20.0",
 ]
 dev_requires = ["Sphinx>=2.2.1", "pytest>=3.8.0"]
 crawl_requires = [


### PR DESCRIPTION
The "packaging" module was needed for the conrad to work, which was not included in the setup.py. Adding that to the requirements list so using pip install conference-radar works out of the box without needing to manual tweaking. 